### PR TITLE
feat: rename option `--cloudformations` -> `--cloudformation-stacks`

### DIFF
--- a/docs/running-locally.md
+++ b/docs/running-locally.md
@@ -12,11 +12,11 @@ If you already have a default aws profile configured specifying a default region
 
 Here is the full list of available options:
 
-| Option                                       | Effect                                                          |
-| -------------------------------------------- | --------------------------------------------------------------- |
-| -p, --aws-profile \<profile\>                | Aws profile name to use                                         |
-| -r, --aws-region \<region\>                  | Manually set AWS region                                         |
-| -c, --cloudformations \[cloudformations...\] | Filter checked account resources by cloudformation stacks names |
-| -t, --tags \<key_value...\>                  | Filter checked account resources by tags                        |
-| -s, --short                                  | Short output: only display checks results overview              |
-| --noFail                                     | Exit with success status, even if some checks failed            |
+| Option                                            | Effect                                                          |
+| ------------------------------------------------- | --------------------------------------------------------------- |
+| -p, --aws-profile \<profile\>                     | Aws profile name to use                                         |
+| -r, --aws-region \<region\>                       | Manually set AWS region                                         |
+| -c, --cloudformation-stacks \<stack1 stack2 ...\> | Filter checked account resources by cloudformation stacks names |
+| -t, --tags \<Key=...,Value=... Ke...\>            | Filter checked account resources by tags                        |
+| -s, --short                                       | Short output: only display checks results overview              |
+| --noFail                                          | Exit with success status, even if some checks failed            |

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,7 +1,6 @@
 #!/usr/bin/env node
 import { Command, InvalidArgumentError, program } from 'commander';
 
-import { runGuardianChecks } from './index';
 import {
   displayChecksStarting,
   displayDashboard,
@@ -9,6 +8,7 @@ import {
   displayGuordle,
   displayResultsSummary,
 } from './display';
+import { runGuardianChecks } from './index';
 import { Options, Tag } from './types/CliOptions';
 import { getResultsByCategory } from './helpers/getResultsByCategory';
 
@@ -94,9 +94,14 @@ program
     'Filter checked account resources by tags',
     parseTags,
   )
+  /** @deprecated use --cloudformation-stacks instead */
   .option(
-    '-c, --cloudformations [cloudformations...]',
-    'Filter checked account resources by cloudformation stacks names',
+    '--cloudformations [cloudformation-stacks...]',
+    'Filter checked account resources by CloudFormation stack names',
+  )
+  .option(
+    '-c, --cloudformation-stacks [cloudformation-stacks...]',
+    'Filter checked account resources by CloudFormation stack names',
   )
   .option(
     '--noFail',

--- a/src/helpers/fetchCloudFormationResourceArns.ts
+++ b/src/helpers/fetchCloudFormationResourceArns.ts
@@ -11,16 +11,16 @@ import {
 } from './getSupportedResourceArn';
 
 export const fetchCloudFormationResourceArns = async (
-  cloudformations: string[],
+  cloudformationStacks: string[],
 ): Promise<ARN[]> => {
   const cloudFormationClient = new CloudFormationClient({});
   const stsClient = new STSClient({});
 
   const resources: StackResourceSummary[] = [];
-  for (const cloudformation of cloudformations) {
+  for (const stack of cloudformationStacks) {
     for await (const page of paginateListStackResources(
       { client: cloudFormationClient },
-      { StackName: cloudformation },
+      { StackName: stack },
     )) {
       resources.push(...(page.StackResourceSummaries ?? []));
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,18 +21,18 @@ import { ChecksResults, Options, Rule, Tag } from './types';
 import { displayError, progressBar } from './display';
 
 const fetchResourceArns = async (
-  cloudformations: string[] | undefined,
+  cloudformationStacks: string[] | undefined,
   tags: Tag[] | undefined,
 ) => {
   try {
     const resourcesFetchedByTags = await fetchTaggedResourceArns(tags ?? []);
 
-    if (cloudformations === undefined) {
+    if (cloudformationStacks === undefined) {
       return resourcesFetchedByTags;
     }
 
     const resourcesFetchedByStack = await fetchCloudFormationResourceArns(
-      cloudformations,
+      cloudformationStacks,
     );
 
     const resources = intersectionWith(
@@ -45,7 +45,7 @@ const fetchResourceArns = async (
     return resources;
   } catch {
     displayError(
-      `Unable to fetch AWS resources, check that profile "${
+      `Unable to fetch AWS resources, check that the profile "${
         process.env.AWS_PROFILE ?? ''
       }" is correctly set or specify another profile using -p option`,
     );
@@ -56,9 +56,13 @@ const fetchResourceArns = async (
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 export const runGuardianChecks = async ({
   cloudformations,
+  cloudformationStacks,
   tags,
 }: Options): Promise<ChecksResults> => {
-  const resourceArns = await fetchResourceArns(cloudformations, tags);
+  const resourceArns = await fetchResourceArns(
+    cloudformationStacks ?? cloudformations,
+    tags,
+  );
   const rules: Rule[] = [
     LightBundleRule,
     NoIdenticalCode,

--- a/src/rules/noMaxTimeout/index.ts
+++ b/src/rules/noMaxTimeout/index.ts
@@ -21,7 +21,7 @@ const run: Rule['run'] = async resourceArns => {
 };
 
 const rule: Rule = {
-  ruleName: 'Lambda No Maximum Timeout',
+  ruleName: 'Lambda: No Maximum Timeout',
   errorMessage: 'The following functions have their timeout set as the maximum',
   run,
   fileName: 'noMaxTimeout',

--- a/src/types/CliOptions.ts
+++ b/src/types/CliOptions.ts
@@ -8,6 +8,8 @@ export type Options = {
   awsRegion?: string;
   short: boolean;
   tags?: Tag[];
+  /** @deprecated use cloudformationStacks instead */
   cloudformations?: string[];
+  cloudformationStacks?: string[];
   noFail: boolean;
 };


### PR DESCRIPTION
`--cloudformations` is not accurate and should be replaced by `--cloudformation-stacks` (or maybe `--stacks`).
