### PR TITLE
feat: add rule: security headers on CloudFront

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,5 +5,8 @@
       "source.organizeImports":true,
       "source.fixAll.eslint": true,
       "source.fixAll.stylelint": true
+    },
+    "search.exclude": {
+      "**/dist": true
     }
   }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,12 +1,12 @@
 {
-    "editor.defaultFormatter": "esbenp.prettier-vscode",
-    "editor.formatOnSave": true,
-    "editor.codeActionsOnSave": {
-      "source.organizeImports":true,
-      "source.fixAll.eslint": true,
-      "source.fixAll.stylelint": true
-    },
-    "search.exclude": {
-      "**/dist": true
-    }
+  "editor.defaultFormatter": "esbenp.prettier-vscode",
+  "editor.formatOnSave": true,
+  "editor.codeActionsOnSave": {
+    "source.organizeImports": true,
+    "source.fixAll.eslint": true,
+    "source.fixAll.stylelint": true
+  },
+  "search.exclude": {
+    "**/dist": true
   }
+}

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
   },
   "dependencies": {
     "@aws-sdk/client-cloudformation": "^3.99.0",
+    "@aws-sdk/client-cloudfront": "^3.226.0",
     "@aws-sdk/client-cloudwatch-logs": "^3.193.0",
     "@aws-sdk/client-cognito-identity-provider": "^3.193.0",
     "@aws-sdk/client-eventbridge": "^3.193.0",

--- a/src/aws-sdk-helpers/cloudFront/fetchAllDistributions.ts
+++ b/src/aws-sdk-helpers/cloudFront/fetchAllDistributions.ts
@@ -1,0 +1,38 @@
+import {
+  Distribution,
+  GetDistributionCommand,
+} from '@aws-sdk/client-cloudfront';
+import { cloudFrontClient } from '../../clients';
+import { GuardianARN } from '../../types';
+import { CloudFrontDistributionARN } from '../../types/arn/cloudFront';
+
+const fetchDistribution = async (
+  Id: string,
+): Promise<Distribution | undefined> => {
+  const { Distribution: distribution } = await cloudFrontClient.send(
+    new GetDistributionCommand({ Id }),
+  );
+
+  return distribution;
+};
+
+export const fetchAllDistributions = async (
+  resourceArns: GuardianARN[],
+): Promise<Distribution[]> => {
+  const distributionArns = GuardianARN.filterArns(
+    resourceArns,
+    CloudFrontDistributionARN,
+  );
+
+  const distributionIds = distributionArns.map(arn => arn.getDistributionId());
+
+  const distributions = await Promise.all(
+    distributionIds.map(fetchDistribution),
+  );
+
+  const definedDistributions = distributions.filter(
+    (distribution): distribution is Distribution => distribution !== undefined,
+  );
+
+  return definedDistributions;
+};

--- a/src/aws-sdk-helpers/cloudFront/fetchResponseHeaderPolicyById.ts
+++ b/src/aws-sdk-helpers/cloudFront/fetchResponseHeaderPolicyById.ts
@@ -1,0 +1,19 @@
+import {
+  GetResponseHeadersPolicyCommand,
+  ResponseHeadersPolicy,
+} from '@aws-sdk/client-cloudfront';
+import { cloudFrontClient } from '../../clients';
+
+const fetchResponseHeaderPolicyById = async (
+  id: string | undefined,
+): Promise<ResponseHeadersPolicy | undefined> => {
+  const command = new GetResponseHeadersPolicyCommand({ Id: id });
+
+  const commandOutput = await cloudFrontClient.send(command);
+
+  const policy = commandOutput.ResponseHeadersPolicy;
+
+  return policy;
+};
+
+export default fetchResponseHeaderPolicyById;

--- a/src/aws-sdk-helpers/cloudFront/getDistributionResponseHeadersPolicyIds.ts
+++ b/src/aws-sdk-helpers/cloudFront/getDistributionResponseHeadersPolicyIds.ts
@@ -1,0 +1,29 @@
+import { Distribution } from '@aws-sdk/client-cloudfront';
+
+const getDistributionResponseHeadersPolicyIds = (
+  distribution: Distribution,
+): (string | undefined)[] => {
+  if (distribution.DistributionConfig === undefined) {
+    return [];
+  }
+
+  const defaultCacheBehavior =
+    distribution.DistributionConfig.DefaultCacheBehavior;
+
+  if (defaultCacheBehavior === undefined) {
+    return [];
+  }
+
+  const cacheBehaviors =
+    distribution.DistributionConfig.CacheBehaviors?.Items ?? [];
+
+  const allCacheBehaviors = [defaultCacheBehavior, ...cacheBehaviors];
+
+  const responseHeadersPolicyIds = allCacheBehaviors.map(
+    ({ ResponseHeadersPolicyId }) => ResponseHeadersPolicyId,
+  );
+
+  return responseHeadersPolicyIds;
+};
+
+export default getDistributionResponseHeadersPolicyIds;

--- a/src/aws-sdk-helpers/cloudFront/index.ts
+++ b/src/aws-sdk-helpers/cloudFront/index.ts
@@ -1,0 +1,1 @@
+export * from './fetchAllDistributions';

--- a/src/checks.ts
+++ b/src/checks.ts
@@ -1,6 +1,7 @@
 import { MultiBar, Presets } from 'cli-progress';
 import {
   AsyncSpecifyFailureDestination,
+  CloudFrontSecurityHeaders,
   CognitoSignInCaseInsensitivity,
   DefinedLogsRetentionDuration,
   LightBundleRule,
@@ -47,6 +48,7 @@ export const runChecks = async (
     CognitoSignInCaseInsensitivity,
     DefinedLogsRetentionDuration,
     SpecifyDlqOnEventBridgeRule,
+    CloudFrontSecurityHeaders,
   ];
 
   const rulesToRunAccordingToLevel = allRules.filter(

--- a/src/clients/cloudFrontClient.ts
+++ b/src/clients/cloudFrontClient.ts
@@ -1,0 +1,5 @@
+import { CloudFrontClient } from '@aws-sdk/client-cloudfront';
+
+const cloudFrontClient = new CloudFrontClient({});
+
+export default cloudFrontClient;

--- a/src/clients/index.ts
+++ b/src/clients/index.ts
@@ -1,3 +1,4 @@
+export { default as cloudFrontClient } from './cloudFrontClient';
 export { default as cloudWatchLogsClient } from './cloudWatchLogsClient';
 export { default as cognitoIdpClient } from './cognitoIdpClient';
 export { default as eventBridgeClient } from './eventBridgeClient';

--- a/src/init/fetchCloudFormationResourceArns.ts
+++ b/src/init/fetchCloudFormationResourceArns.ts
@@ -12,6 +12,7 @@ import {
   S3BucketARN,
   SqsQueueARN,
 } from '../types';
+import { CloudFrontDistributionARN } from '../types/arn/cloudFront';
 
 // This is a big switch
 // eslint-disable-next-line complexity
@@ -36,6 +37,8 @@ export const createARNFromCloudFormation = ({
       return CloudwatchLogGroupARN.fromPhysicalId(PhysicalResourceId);
     case 'AWS::Events::EventBus':
       return EventBridgeEventBusARN.fromPhysicalId(PhysicalResourceId);
+    case 'AWS::CloudFront::Distribution':
+      return CloudFrontDistributionARN.fromPhysicalId(PhysicalResourceId);
     default:
       return;
   }

--- a/src/init/listResources/cloudfront/index.ts
+++ b/src/init/listResources/cloudfront/index.ts
@@ -1,0 +1,1 @@
+export * from './listCloudFrontDistributions';

--- a/src/init/listResources/cloudfront/listCloudFrontDistributions.ts
+++ b/src/init/listResources/cloudfront/listCloudFrontDistributions.ts
@@ -1,0 +1,23 @@
+import {
+  DistributionSummary,
+  paginateListDistributions,
+} from '@aws-sdk/client-cloudfront';
+import { cloudFrontClient } from '../../../clients';
+import { CloudFrontDistributionARN } from '../../../types/arn/cloudFront';
+
+export const listCloudFrontDistributions = async (): Promise<
+  CloudFrontDistributionARN[]
+> => {
+  const cloudFrontDistributions: DistributionSummary[] = [];
+
+  for await (const resources of paginateListDistributions(
+    { client: cloudFrontClient },
+    {},
+  )) {
+    cloudFrontDistributions.push(...(resources.DistributionList?.Items ?? []));
+  }
+
+  return cloudFrontDistributions.map(({ Id }) =>
+    CloudFrontDistributionARN.fromDistributionId(Id ?? ''),
+  );
+};

--- a/src/init/listResources/listAllResources.ts
+++ b/src/init/listResources/listAllResources.ts
@@ -7,6 +7,8 @@ import {
   S3BucketARN,
   SqsQueueARN,
 } from '../../types';
+import { CloudFrontDistributionARN } from '../../types/arn/cloudFront';
+import { listCloudFrontDistributions } from './cloudfront';
 import { listCloudwatchLogGroups } from './cloudwatch';
 import { listCognitoUserPools } from './cognito';
 import { listEventBridgeEventBuses } from './eventBridge';
@@ -23,6 +25,8 @@ export const listAllResources = async (): Promise<GuardianARN[]> => {
     await listCloudwatchLogGroups();
   const eventBridgeEventBuses: EventBridgeEventBusARN[] =
     await listEventBridgeEventBuses();
+  const cloudFrontDistributions: CloudFrontDistributionARN[] =
+    await listCloudFrontDistributions();
 
   return [
     ...s3buckets,
@@ -31,5 +35,6 @@ export const listAllResources = async (): Promise<GuardianARN[]> => {
     ...cognitoUserPools,
     ...cloudWatchLogGroups,
     ...eventBridgeEventBuses,
+    ...cloudFrontDistributions,
   ];
 };

--- a/src/rules/cloudFrontSecurityHeaders/cloudFrontSecurityHeaders.md
+++ b/src/rules/cloudFrontSecurityHeaders/cloudFrontSecurityHeaders.md
@@ -1,0 +1,13 @@
+# CloudFront: use SecurityHeadersPolicy on the cache behaviors of your distributions
+
+A **cache behavior** lets you configure how your users will access your files (more on
+[CloudFront cache behaviors][cloudfront-cache-behaviors]).
+
+In particular, you can configure which **HTTP headers** will be used in CloudFront responses.
+
+You should add **security headers** to your CloudFront distributions to protect your users.
+Security headers either prevent basic attacks or add a layer of security-in-depth.
+
+AWS provides a managed policy _SecurityHeadersPolicy_ that you can use easily. Head over to your console, `CloudFront > Distributions > Behaviors`. Then edit the behaviors: select `SecurityHeadersPolicy` in the _Response headers policy - optional_ section.
+
+[cloudfront-cache-behaviors]: https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/distribution-web-values-specify.html#DownloadDistValuesCacheBehavior

--- a/src/rules/cloudFrontSecurityHeaders/index.ts
+++ b/src/rules/cloudFrontSecurityHeaders/index.ts
@@ -1,0 +1,58 @@
+import { Distribution } from '@aws-sdk/client-cloudfront';
+import { fetchAllDistributions } from '../../aws-sdk-helpers/cloudFront';
+import getDistributionResponseHeadersPolicyIds from '../../aws-sdk-helpers/cloudFront/getDistributionResponseHeadersPolicyIds';
+import { GuardianLevel } from '../../constants/level';
+import { Category, Rule } from '../../types';
+import { CloudFrontDistributionARN } from '../../types/arn/cloudFront';
+
+const areSecurityHeadersEnabled = (distribution: Distribution) => {
+  const responseHeadersPolicyIds =
+    getDistributionResponseHeadersPolicyIds(distribution);
+
+  /**
+   * Let's hard code the ID of the policy that has the security headers and is managed by AWS.
+   */
+  if (
+    responseHeadersPolicyIds.includes('67f7725c-6f97-4210-82d7-5512b31e9d03')
+  ) {
+    return true;
+  }
+
+  /**
+   * TODO: analyze the response headers policies to ensure all security headers are present
+   * In fact, not only the managed policy '67f7725c-6f97-4210-82d7-5512b31e9d03' has the headers,
+   * but the custom policies may also have them.
+   *
+   * const responseHeadersPolicies = await Promise.all(
+   *   responseHeadersPolicyIds.map(fetchResponseHeaderPolicyById),
+   * );
+   *
+   * ...
+   */
+
+  return false;
+};
+
+const run: Rule['run'] = async resourceArns => {
+  const distributions = await fetchAllDistributions(resourceArns);
+
+  const results = distributions.map(distribution => ({
+    arn: CloudFrontDistributionARN.fromDistributionId(distribution.Id ?? ''),
+    success: areSecurityHeadersEnabled(distribution),
+  }));
+
+  return { results };
+};
+
+const rule: Rule = {
+  ruleName:
+    'CloudFront: use SecurityHeadersPolicy on the cache behaviors of your distributions',
+  errorMessage:
+    'SecurityHeadersPolicy is not enabled on a behavior of the distribution',
+  run,
+  fileName: 'cloudFrontSecurityHeaders',
+  categories: [Category.SECURITY],
+  level: GuardianLevel.Level1,
+};
+
+export default rule;

--- a/src/rules/index.ts
+++ b/src/rules/index.ts
@@ -1,4 +1,5 @@
 import AsyncSpecifyFailureDestination from './asyncSpecifyFailureDestination';
+import CloudFrontSecurityHeaders from './cloudFrontSecurityHeaders';
 import CognitoSignInCaseInsensitivity from './cognitoSignInCaseInsensitivity';
 import DefinedLogsRetentionDuration from './definedLogsRetentionDuration';
 import LightBundleRule from './lightBundle';
@@ -17,6 +18,7 @@ import UseIntelligentTiering from './useIntelligentTiering';
 
 export {
   CognitoSignInCaseInsensitivity,
+  CloudFrontSecurityHeaders,
   noDefaultMemory,
   LightBundleRule,
   NoMaxTimeout,

--- a/src/types/arn/cloudFront/cloudFrontARN.ts
+++ b/src/types/arn/cloudFront/cloudFrontARN.ts
@@ -1,0 +1,17 @@
+import { GuardianARN } from '../GuardianARN';
+
+export class CloudFrontDistributionARN extends GuardianARN {
+  constructor(resource: string) {
+    super(resource, 'cloudfront');
+  }
+
+  static fromDistributionId = (
+    distributionId: string,
+  ): CloudFrontDistributionARN =>
+    new CloudFrontDistributionARN(`distribution/${distributionId}`);
+
+  static fromPhysicalId = (physicalId: string): CloudFrontDistributionARN =>
+    CloudFrontDistributionARN.fromDistributionId(physicalId);
+
+  getDistributionId = (): string => this.resource.split('/')[1];
+}

--- a/src/types/arn/cloudFront/index.ts
+++ b/src/types/arn/cloudFront/index.ts
@@ -1,0 +1,1 @@
+export * from './cloudFrontARN';


### PR DESCRIPTION
SecurityHeadersPolicy should be applied on the CloudFront distributions.

This PR add this rule to Level 1.

Current limitations:
- even if the distribution is disabled, the rule will be triggered,
- even if proper headers are set and if the user configured them manually, the rule will be triggered.