### PR TITLE
Ignore resources chosen by user

### DIFF
--- a/src/checks.ts
+++ b/src/checks.ts
@@ -71,8 +71,18 @@ export const runChecks = async (
 
   const results = await Promise.all(
     rulesToRunAccordingToLevel.map(async rule => {
+      const ignoredArnPatterns =
+        rulesConfigurations?.[rule.fileName]?.ignoredResources;
+
+      const filteredResourcesArns = ignoredArnPatterns
+        ? GuardianARN.filterIgnoredArns(allResourceArns, ignoredArnPatterns)
+        : allResourceArns;
+
       const ruleResult = (
-        await rule.run(allResourceArns, rulesConfigurations?.[rule.fileName])
+        await rule.run(
+          filteredResourcesArns,
+          rulesConfigurations?.[rule.fileName],
+        )
       ).results;
       decreaseRemaining();
 

--- a/src/checks.ts
+++ b/src/checks.ts
@@ -16,11 +16,12 @@ import {
   UseArm,
   UseIntelligentTiering,
 } from './rules';
-import { ChecksResults, GuardianARN, Rule } from './types';
+import { ChecksResults, GuardianARN, Rule, RuleConfiguration } from './types';
 
 export const runChecks = async (
   allResourceArns: GuardianARN[],
   level: number,
+  rulesConfigurations?: Record<string, RuleConfiguration>,
 ): Promise<ChecksResults> => {
   const progressBar = new MultiBar(
     { emptyOnZero: true, hideCursor: true },
@@ -70,7 +71,9 @@ export const runChecks = async (
 
   const results = await Promise.all(
     rulesToRunAccordingToLevel.map(async rule => {
-      const ruleResult = (await rule.run(allResourceArns)).results;
+      const ruleResult = (
+        await rule.run(allResourceArns, rulesConfigurations?.[rule.fileName])
+      ).results;
       decreaseRemaining();
 
       return { rule, result: ruleResult };

--- a/src/configuration/utils/readConfiguration.ts
+++ b/src/configuration/utils/readConfiguration.ts
@@ -1,0 +1,14 @@
+import * as fs from 'fs';
+import { Configuration } from '../../types';
+
+export const readConfiguration = (): Configuration => {
+  try {
+    const rawConfig = fs.readFileSync('guardian.json', 'utf-8');
+    const configuration = JSON.parse(rawConfig) as Configuration;
+
+    return configuration;
+  } catch {
+    // if no config is found, return empty object
+    return {};
+  }
+};

--- a/src/guardian.ts
+++ b/src/guardian.ts
@@ -24,9 +24,9 @@ export const runGuardian = async (
 
   await initAccountAndRegion();
 
-  let allReourcesArns: GuardianARN[];
+  let allResourcesArns: GuardianARN[];
   try {
-    allReourcesArns = await fetchAllResourceArns({
+    allResourcesArns = await fetchAllResourceArns({
       cloudformationStacks:
         options.cloudformationStacks ?? options.cloudformations,
       tags: options.tags,
@@ -48,7 +48,11 @@ export const runGuardian = async (
     return { success: false };
   }
 
-  const checksResults = await runChecks(allReourcesArns, level);
+  const checksResults = await runChecks(
+    allResourcesArns,
+    level,
+    configuration.rules,
+  );
 
   const atLeastOneFailed = checksResults.some(
     ({ result }) => result.filter(resource => !resource.success).length > 0,

--- a/src/guardian.ts
+++ b/src/guardian.ts
@@ -1,4 +1,5 @@
 import { runChecks } from './checks';
+import { readConfiguration } from './configuration/utils/readConfiguration';
 import {
   displayChecksStarting,
   displayDashboard,
@@ -16,6 +17,7 @@ import { getGuardianLevel } from './utils/getGuardianLevel';
 export const runGuardian = async (
   options: Options,
 ): Promise<{ success: boolean; checksResults?: ChecksResults }> => {
+  const configuration = readConfiguration();
   const level = await getGuardianLevel(options);
 
   displayChecksStarting();

--- a/src/types/Rule.ts
+++ b/src/types/Rule.ts
@@ -26,7 +26,10 @@ export interface Rule<T extends RuleConfiguration = BaseConfiguration> {
   ruleName: string;
   errorMessage: string;
   fileName: string;
-  run: (resources: GuardianARN[]) => Promise<{
+  run: (
+    resources: GuardianARN[],
+    configuration?: T,
+  ) => Promise<{
     results: RuleCheckResult[];
   }>;
   categories: Category[];

--- a/src/types/arn/GuardianARN.ts
+++ b/src/types/arn/GuardianARN.ts
@@ -36,5 +36,16 @@ export class GuardianARN implements ARN {
     childClass: GuardianARNSubClass<T>,
   ): T[] => arns.filter(GuardianARN.checkArnType(childClass));
 
+  static filterIgnoredArns = <T extends GuardianARN>(
+    arns: T[],
+    ignoredArnPatterns: string[],
+  ): T[] =>
+    arns.filter(
+      arn =>
+        ignoredArnPatterns.findIndex(ignoredPattern =>
+          arn.toString().match(ignoredPattern),
+        ) < 0,
+    );
+
   toString = (): string => build(this);
 }


### PR DESCRIPTION
You can ignore resource by adding a guardian.json file.

For instance: 
```json
{
  "rules": {
    "useArm": {
      "ignoredResources": [".*"]
    },
   "definedLogsRetentionDuration": {
      "ignoredResources": ["LogGroupGuardian"]
  }
}
```
Will ignore all resources for useArm rule and resources containing LogGroupGuardian for definedLogsRetentionDuration rule

What's next:
[ ] Test configuration
[ ] Document how to configure guardian